### PR TITLE
Fix Theme Review issues

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,9 +1,4 @@
 <?php
-add_action( 'wp_enqueue_scripts', 'theme_enqueue_styles' );
-function theme_enqueue_styles() {
-  wp_enqueue_style( 'parent-style', get_template_directory_uri() . '/style.css' );
-}
-
 //hooks
 add_filter( 'the_content' , 'willow_the_content_filter' );
 
@@ -22,11 +17,12 @@ function willow_make_excerpt($content){
     return $content;
 }
 
-function register_script(){
+function willow_register_script(){
     wp_register_script( 'willow', get_stylesheet_directory_uri() . '/js/willow.js', array( 'jquery' ), '', true);
 }
-function add_script() {
-    register_script();
+function willow_add_script() {
+    willow_register_script();
     wp_enqueue_script('willow');
+    wp_enqueue_style( 'parent-style', get_template_directory_uri() . '/style.css' );
 }
-add_action('wp_enqueue_scripts', 'add_script');
+add_action('wp_enqueue_scripts', 'willow_add_script');

--- a/header.php
+++ b/header.php
@@ -24,7 +24,7 @@
 <body <?php body_class(); ?>>
 <div id="page" class="hfeed site">
 	<div class="site-inner">
-		<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'twentysixteen' ); ?></a>
+		<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'willow' ); ?></a>
 
 		<header id="masthead" class="site-header" role="banner">
 			<div class="site-header-main">
@@ -42,11 +42,11 @@
 				</div><!-- .site-branding -->
 
 				<?php if ( has_nav_menu( 'primary' ) || has_nav_menu( 'social' ) ) : ?>
-					<button id="menu-toggle" class="menu-toggle"><?php _e( 'Menu', 'twentysixteen' ); ?></button>
+					<button id="menu-toggle" class="menu-toggle"><?php _e( 'Menu', 'willow' ); ?></button>
 
 					<div id="site-header-menu" class="site-header-menu">
 						<?php if ( has_nav_menu( 'primary' ) ) : ?>
-							<nav id="site-navigation" class="main-navigation" role="navigation" aria-label="<?php _e( 'Primary Menu', 'twentysixteen' ); ?>">
+							<nav id="site-navigation" class="main-navigation" role="navigation" aria-label="<?php _e( 'Primary Menu', 'willow' ); ?>">
 								<?php
 									wp_nav_menu( array(
 										'theme_location' => 'primary',
@@ -57,7 +57,7 @@
 						<?php endif; ?>
 
 						<?php if ( has_nav_menu( 'social' ) ) : ?>
-							<nav id="social-navigation" class="social-navigation" role="navigation" aria-label="<?php _e( 'Social Links Menu', 'twentysixteen' ); ?>">
+							<nav id="social-navigation" class="social-navigation" role="navigation" aria-label="<?php _e( 'Social Links Menu', 'willow' ); ?>">
 								<?php
 									wp_nav_menu( array(
 										'theme_location' => 'social',

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -24,11 +24,11 @@
 			the_content();
 
 			wp_link_pages( array(
-				'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'twentysixteen' ) . '</span>',
+				'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'willow' ) . '</span>',
 				'after'       => '</div>',
 				'link_before' => '<span>',
 				'link_after'  => '</span>',
-				'pagelink'    => '<span class="screen-reader-text">' . __( 'Page', 'twentysixteen' ) . ' </span>%',
+				'pagelink'    => '<span class="screen-reader-text">' . __( 'Page', 'willow' ) . ' </span>%',
 				'separator'   => '<span class="screen-reader-text">, </span>',
 			) );
 
@@ -44,7 +44,7 @@
 			edit_post_link(
 				sprintf(
 					/* translators: %s: Name of current post */
-					__( 'Edit %s', 'twentysixteen' ),
+					__( 'Edit %s', 'willow' ),
 					the_title( '<span class="screen-reader-text">', '</span>', false )
 				),
 				'<span class="edit-link">',

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -11,7 +11,7 @@
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<header class="entry-header">
 		<?php if ( is_sticky() && is_home() && ! is_paged() ) : ?>
-			<span class="sticky-post"><?php _e( 'Featured', 'twentysixteen' ); ?></span>
+			<span class="sticky-post"><?php _e( 'Featured', 'willow' ); ?></span>
 		<?php endif; ?>
 
 		<?php twentysixteen_post_thumbnail(); ?>
@@ -25,16 +25,16 @@
 		<?php
 			/* translators: %s: Name of current post */
 			the_content( sprintf(
-				__( 'Continue reading %s', 'twentysixteen' ),
+				__( 'Continue reading %s', 'willow' ),
 				the_title( '<span class="screen-reader-text">"', '"</span>', false )
 			) );
 
 			wp_link_pages( array(
-				'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'twentysixteen' ) . '</span>',
+				'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'willow' ) . '</span>',
 				'after'       => '</div>',
 				'link_before' => '<span>',
 				'link_after'  => '</span>',
-				'pagelink'    => '<span class="screen-reader-text">' . __( 'Page', 'twentysixteen' ) . ' </span>%',
+				'pagelink'    => '<span class="screen-reader-text">' . __( 'Page', 'willow' ) . ' </span>%',
 				'separator'   => '<span class="screen-reader-text">, </span>',
 			) );
 		?>
@@ -46,7 +46,7 @@
 			edit_post_link(
 				sprintf(
 					/* translators: %s: Name of current post */
-					__( 'Edit %s', 'twentysixteen' ),
+					__( 'Edit %s', 'willow' ),
 					the_title( '<span class="screen-reader-text">', '</span>', false )
 				),
 				'<span class="edit-link">',


### PR DESCRIPTION
> The text domain in your translations should be willow, not twentysixteen.
> Example:
> <?php _e( 'Skip to content', 'twentysixteen' ); ?></a> 
> Should be
> <?php _e( 'Skip to content', 'willow' ); ?></a>
> Some of your functions are named correctly but not all.
> Example:
> function register_script() should be
> function willow_register_script() or similar.
